### PR TITLE
Add Package::get_local_version

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -6,6 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use anyhow::{Context, Result};
+use cargo_metadata::MetadataCommand;
+
 /// A package in the workspace.
 pub struct Package(String);
 
@@ -23,5 +26,21 @@ impl Package {
     /// Format a package version as a git tag.
     pub fn get_git_tag_name(&self, local_version: &str) -> String {
         format!("{}-v{}", self.name(), local_version)
+    }
+
+    /// Use the `cargo_metadata` crate to get the local version of a package
+    /// in the workspace.
+    pub fn get_local_version(&self) -> Result<String> {
+        let mut cmd = MetadataCommand::new();
+        // Ignore deps, we only need local packages.
+        cmd.no_deps();
+        let local_metadata = cmd.exec()?;
+
+        let metadata = local_metadata
+            .packages
+            .iter()
+            .find(|pm| pm.name == self.name())
+            .context(format!("failed to find {} in local metadata", self.name()))?;
+        Ok(metadata.version.to_string())
     }
 }


### PR DESCRIPTION
Remove the free-standing functions and cached local_metadata. This may be slightly less efficient for releasing multiple crates from the workspace, but makes the API nicer.