### PR TITLE
auto-release: Drop --execute flag

### DIFF
--- a/auto-release/README.md
+++ b/auto-release/README.md
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo install auto-release
-      - run: auto-release -p <package> --execute
+      - run: auto-release -p <package>
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
@@ -62,8 +62,6 @@ To make the token available to the Github Actions workflow:
   start with "release:", otherwise the commit will be ignored.
 * `--condition=subject` adds a condition that the commit message subject
   must start with "release:", otherwise the commit will be ignored.
-* `--execute` is required; this is just to prevent the command from
-  doing anything if you run it locally by accident.
 
 [Account Settings]: https://crates.io/settings/tokens
 

--- a/auto-release/src/main.rs
+++ b/auto-release/src/main.rs
@@ -10,7 +10,6 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use release_utils::release::release_packages;
 use release_utils::{get_github_sha, Package, Repo};
-use std::process;
 
 #[derive(ValueEnum, Clone, Copy)]
 enum Condition {
@@ -25,9 +24,6 @@ struct Cli {
 
     #[arg(long)]
     condition: Option<Condition>,
-
-    #[arg(long)]
-    execute: bool,
 }
 
 fn check_condition(condition: Condition) -> Result<bool> {
@@ -73,10 +69,5 @@ fn execute(cli: Cli) -> Result<()> {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    if cli.execute {
-        execute(cli)
-    } else {
-        println!("--execute not passed; stopping");
-        process::exit(1);
-    }
+    execute(cli)
 }


### PR DESCRIPTION
It's not that important, the command will still fail when run with no args since at least one package arg is required. And even then, it won't do anything if GITHUB_SHA isn't in the environment.