### PR TITLE
auto-release: Drop clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "anstyle"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
-
-[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,7 +19,6 @@ name = "auto-release"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "clap",
  "release-utils",
 ]
 
@@ -99,44 +92,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "4.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "crates-index"
@@ -230,12 +185,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hex"

--- a/auto-release/Cargo.toml
+++ b/auto-release/Cargo.toml
@@ -20,5 +20,4 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.0"
-clap = { version = "4.4.0", default-features = false, features = ["derive", "help", "std"] }
 release-utils = { version = "0.4.0", path = "../release-utils" }

--- a/auto-release/src/args.rs
+++ b/auto-release/src/args.rs
@@ -1,0 +1,237 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Parse command-line arguments.
+//!
+//! This executable has a very simple interface, so we can implement it
+//! manually rather than using a full-featured crate like `clap`. This
+//! improves from-scratch compilation time, which matters for `cargo
+//! install`.
+
+use std::{env, process};
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Condition {
+    Body,
+    Subject,
+}
+
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct Cli {
+    pub package: Vec<String>,
+    pub condition: Option<Condition>,
+}
+
+const USAGE: &str = r#"Usage:
+auto-release -p <PKG> [-p <PKG>...] [--condition body|subject]
+
+Options:
+  -p, --package <PACKAGE>
+      --condition <CONDITION>  [possible values: body, subject]
+  -h, --help                   Print help
+"#;
+
+enum ArgState {
+    Any,
+    Package,
+    Condition,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum ArgParseResult {
+    Success(Cli),
+    ShowUsage,
+    InvalidArg,
+    InvalidCondition,
+    MissingValue,
+    MissingPackage,
+}
+
+/// Parse arguments from a `String` iterator.
+fn parse_args_from_iter(
+    mut args: impl Iterator<Item = String>,
+) -> ArgParseResult {
+    let mut cli = Cli::default();
+
+    let mut arg_state = ArgState::Any;
+    // Skip the first arg, name of program.
+    args.next();
+
+    for arg in args {
+        match arg_state {
+            ArgState::Any => {
+                if arg == "-p" || arg == "--package" {
+                    arg_state = ArgState::Package;
+                } else if arg == "--condition" {
+                    arg_state = ArgState::Condition;
+                } else if arg == "-h" || arg == "--help" {
+                    return ArgParseResult::ShowUsage;
+                } else {
+                    return ArgParseResult::InvalidArg;
+                }
+            }
+            ArgState::Package => {
+                cli.package.push(arg);
+                arg_state = ArgState::Any;
+            }
+            ArgState::Condition => {
+                if arg == "body" {
+                    cli.condition = Some(Condition::Body);
+                } else if arg == "subject" {
+                    cli.condition = Some(Condition::Subject);
+                } else {
+                    return ArgParseResult::InvalidCondition;
+                }
+                arg_state = ArgState::Any;
+            }
+        }
+    }
+
+    if !matches!(arg_state, ArgState::Any) {
+        return ArgParseResult::MissingValue;
+    }
+
+    if cli.package.is_empty() {
+        return ArgParseResult::MissingPackage;
+    }
+
+    ArgParseResult::Success(cli)
+}
+
+/// Parse command-line arguments.
+pub fn parse_args() -> Cli {
+    let err = match parse_args_from_iter(env::args()) {
+        ArgParseResult::Success(cli) => {
+            return cli;
+        }
+        ArgParseResult::ShowUsage => {
+            print!("{USAGE}");
+            process::exit(0);
+        }
+        ArgParseResult::InvalidArg => "invalid arg",
+        ArgParseResult::InvalidCondition => "invalid condition",
+        ArgParseResult::MissingValue => "missing arg value",
+        ArgParseResult::MissingPackage => {
+            "at least one package must be specified"
+        }
+    };
+
+    println!("error: {err}");
+    print!("{USAGE}");
+    process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(s: &[&str]) -> impl Iterator<Item = String> {
+        s.iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    #[test]
+    fn test_arg_parse() {
+        assert_eq!(
+            parse_args_from_iter(args(&[])),
+            ArgParseResult::MissingPackage
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release"])),
+            ArgParseResult::MissingPackage
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "-a"])),
+            ArgParseResult::InvalidArg
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "-p"])),
+            ArgParseResult::MissingValue
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "--condition"])),
+            ArgParseResult::MissingValue
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "--condition", "foo"])),
+            ArgParseResult::InvalidCondition
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "-p", "foo"])),
+            ArgParseResult::Success(Cli {
+                package: vec!["foo".to_string()],
+                condition: None,
+            })
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&[
+                "auto-release",
+                "-p",
+                "foo",
+                "--package",
+                "bar"
+            ])),
+            ArgParseResult::Success(Cli {
+                package: vec!["foo".to_string(), "bar".to_string()],
+                condition: None,
+            })
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&[
+                "auto-release",
+                "-p",
+                "foo",
+                "--condition",
+                "body"
+            ])),
+            ArgParseResult::Success(Cli {
+                package: vec!["foo".to_string()],
+                condition: Some(Condition::Body),
+            })
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&[
+                "auto-release",
+                "-p",
+                "foo",
+                "--condition",
+                "subject"
+            ])),
+            ArgParseResult::Success(Cli {
+                package: vec!["foo".to_string()],
+                condition: Some(Condition::Subject),
+            })
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "-h"])),
+            ArgParseResult::ShowUsage
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "--help"])),
+            ArgParseResult::ShowUsage
+        );
+
+        assert_eq!(
+            parse_args_from_iter(args(&["auto-release", "-h", "-p"])),
+            ArgParseResult::ShowUsage
+        );
+    }
+}

--- a/auto-release/src/main.rs
+++ b/auto-release/src/main.rs
@@ -8,25 +8,12 @@
 
 #![deny(unsafe_code)]
 
+mod args;
+
 use anyhow::Result;
-use clap::{Parser, ValueEnum};
+use args::{parse_args, Cli, Condition};
 use release_utils::release::release_packages;
 use release_utils::{get_github_sha, Package, Repo};
-
-#[derive(ValueEnum, Clone, Copy)]
-enum Condition {
-    Body,
-    Subject,
-}
-
-#[derive(Parser)]
-struct Cli {
-    #[arg(short, long, required = true)]
-    package: Vec<String>,
-
-    #[arg(long)]
-    condition: Option<Condition>,
-}
 
 fn check_condition(condition: Condition) -> Result<bool> {
     let commit_sha = get_github_sha()?;
@@ -69,7 +56,7 @@ fn execute(cli: Cli) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let cli = parse_args();
 
     execute(cli)
 }


### PR DESCRIPTION
Implement the command-line parsing manually to speed up from-scratch compilation time. The goal is to make `cargo install auto-release` fast.